### PR TITLE
chore: add testing rules to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,13 @@ docs/             Project documentation
 - Use conventional commits (feat:, fix:, chore:)
 - Run `npm run build` before committing to verify the build passes
 
+## Testing
+
+- Every feature and bug fix must include tests
+- Test files use `*.test.ts` or `*.test.tsx` and are co-located next to the source file they test
+- Run `npm run test` before committing to verify all tests pass
+- Tests must pass together with `npm run build` before any commit or PR
+
 ## Agent Orchestrator
 
 This project is managed by Agent Orchestrator (AO). Workers are spawned via `ao spawn` to implement issues autonomously.


### PR DESCRIPTION
## Summary
- Adds a **Testing** section to CLAUDE.md with rules for AO workers and contributors
- Tests are required for all features and bug fixes
- Test files must use `*.test.ts(x)` naming and be co-located with source files
- `npm run test` must pass before committing (alongside `npm run build`)

Closes #7