### PR TITLE
feat: view placeholder pages for all routes

### DIFF
--- a/src/app/(app)/chat/page.test.tsx
+++ b/src/app/(app)/chat/page.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import ChatPage from "./page";
+
+describe("ChatPage", () => {
+  it("renders the page title", () => {
+    render(<ChatPage />);
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("Chat");
+  });
+
+  it("renders a description", () => {
+    render(<ChatPage />);
+    expect(screen.getByText(/primary interaction with the workspace/i)).toBeInTheDocument();
+  });
+});

--- a/src/app/(app)/chat/page.tsx
+++ b/src/app/(app)/chat/page.tsx
@@ -1,12 +1,19 @@
 export default function ChatPage() {
   return (
-    <div className="px-8 py-8 lg:px-12 lg:py-10">
-      <h1 className="font-[var(--font-display)] text-3xl font-bold tracking-[-0.03em] text-white">
-        Chat
-      </h1>
-      <p className="mt-2 max-w-lg font-[var(--font-body)] text-base leading-[1.7] text-white/50">
-        Primary interaction with the workspace. Send tasks and view results.
-      </p>
+    <div className="noise-overlay relative min-h-full">
+      <div className="pointer-events-none absolute inset-0" aria-hidden="true">
+        <div className="absolute top-[-20%] left-[15%] h-[600px] w-[600px] rounded-full bg-[radial-gradient(circle,var(--color-brand-900)_0%,transparent_70%)] opacity-30" />
+        <div className="absolute bottom-[-10%] right-[10%] h-[400px] w-[400px] rounded-full bg-[radial-gradient(circle,var(--color-brand-950)_0%,transparent_70%)] opacity-50" />
+      </div>
+
+      <div className="relative z-10 px-8 py-8 lg:px-12 lg:py-10">
+        <h1 className="font-[var(--font-display)] text-3xl font-bold tracking-[-0.03em] text-white">
+          Chat
+        </h1>
+        <p className="mt-2 max-w-lg font-[var(--font-body)] text-base leading-[1.7] text-white/50">
+          Primary interaction with the workspace. Send tasks to the remote Claude Code agent and view streaming results in real time.
+        </p>
+      </div>
     </div>
   );
 }

--- a/src/app/(app)/jobs/page.test.tsx
+++ b/src/app/(app)/jobs/page.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import JobsPage from "./page";
+
+describe("JobsPage", () => {
+  it("renders the page title", () => {
+    render(<JobsPage />);
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("Scheduled Jobs");
+  });
+
+  it("renders a description", () => {
+    render(<JobsPage />);
+    expect(screen.getByText(/manage recurring workspace tasks/i)).toBeInTheDocument();
+  });
+});

--- a/src/app/(app)/jobs/page.tsx
+++ b/src/app/(app)/jobs/page.tsx
@@ -1,12 +1,19 @@
 export default function JobsPage() {
   return (
-    <div className="px-8 py-8 lg:px-12 lg:py-10">
-      <h1 className="font-[var(--font-display)] text-3xl font-bold tracking-[-0.03em] text-white">
-        Jobs
-      </h1>
-      <p className="mt-2 max-w-lg font-[var(--font-body)] text-base leading-[1.7] text-white/50">
-        Manage recurring workspace tasks and scheduled jobs.
-      </p>
+    <div className="noise-overlay relative min-h-full">
+      <div className="pointer-events-none absolute inset-0" aria-hidden="true">
+        <div className="absolute top-[-20%] left-[15%] h-[600px] w-[600px] rounded-full bg-[radial-gradient(circle,var(--color-brand-900)_0%,transparent_70%)] opacity-30" />
+        <div className="absolute bottom-[-10%] right-[10%] h-[400px] w-[400px] rounded-full bg-[radial-gradient(circle,var(--color-brand-950)_0%,transparent_70%)] opacity-50" />
+      </div>
+
+      <div className="relative z-10 px-8 py-8 lg:px-12 lg:py-10">
+        <h1 className="font-[var(--font-display)] text-3xl font-bold tracking-[-0.03em] text-white">
+          Scheduled Jobs
+        </h1>
+        <p className="mt-2 max-w-lg font-[var(--font-body)] text-base leading-[1.7] text-white/50">
+          Manage recurring workspace tasks and scheduled automation jobs for the remote agent.
+        </p>
+      </div>
     </div>
   );
 }

--- a/src/app/(app)/refinement/page.test.tsx
+++ b/src/app/(app)/refinement/page.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import RefinementPage from "./page";
+
+describe("RefinementPage", () => {
+  it("renders the page title", () => {
+    render(<RefinementPage />);
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("Refinement");
+  });
+
+  it("renders a description", () => {
+    render(<RefinementPage />);
+    expect(screen.getByText(/backlog preparation view/i)).toBeInTheDocument();
+  });
+});

--- a/src/app/(app)/refinement/page.tsx
+++ b/src/app/(app)/refinement/page.tsx
@@ -1,12 +1,19 @@
 export default function RefinementPage() {
   return (
-    <div className="px-8 py-8 lg:px-12 lg:py-10">
-      <h1 className="font-[var(--font-display)] text-3xl font-bold tracking-[-0.03em] text-white">
-        Refinement
-      </h1>
-      <p className="mt-2 max-w-lg font-[var(--font-body)] text-base leading-[1.7] text-white/50">
-        Preparation view and fullscreen refinement mode.
-      </p>
+    <div className="noise-overlay relative min-h-full">
+      <div className="pointer-events-none absolute inset-0" aria-hidden="true">
+        <div className="absolute top-[-20%] left-[15%] h-[600px] w-[600px] rounded-full bg-[radial-gradient(circle,var(--color-brand-900)_0%,transparent_70%)] opacity-30" />
+        <div className="absolute bottom-[-10%] right-[10%] h-[400px] w-[400px] rounded-full bg-[radial-gradient(circle,var(--color-brand-950)_0%,transparent_70%)] opacity-50" />
+      </div>
+
+      <div className="relative z-10 px-8 py-8 lg:px-12 lg:py-10">
+        <h1 className="font-[var(--font-display)] text-3xl font-bold tracking-[-0.03em] text-white">
+          Refinement
+        </h1>
+        <p className="mt-2 max-w-lg font-[var(--font-body)] text-base leading-[1.7] text-white/50">
+          Backlog preparation view and fullscreen refinement mode for grooming sessions with the team.
+        </p>
+      </div>
     </div>
   );
 }

--- a/src/app/(app)/sprint-board/page.test.tsx
+++ b/src/app/(app)/sprint-board/page.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import SprintBoardPage from "./page";
+
+describe("SprintBoardPage", () => {
+  it("renders the page title", () => {
+    render(<SprintBoardPage />);
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("Sprint Board");
+  });
+
+  it("renders a description", () => {
+    render(<SprintBoardPage />);
+    expect(screen.getByText(/jira tickets enriched with po metadata/i)).toBeInTheDocument();
+  });
+});

--- a/src/app/(app)/sprint-board/page.tsx
+++ b/src/app/(app)/sprint-board/page.tsx
@@ -1,12 +1,19 @@
 export default function SprintBoardPage() {
   return (
-    <div className="px-8 py-8 lg:px-12 lg:py-10">
-      <h1 className="font-[var(--font-display)] text-3xl font-bold tracking-[-0.03em] text-white">
-        Sprint Board
-      </h1>
-      <p className="mt-2 max-w-lg font-[var(--font-body)] text-base leading-[1.7] text-white/50">
-        Jira tickets with PO metadata: readiness scores, notes, and status.
-      </p>
+    <div className="noise-overlay relative min-h-full">
+      <div className="pointer-events-none absolute inset-0" aria-hidden="true">
+        <div className="absolute top-[-20%] left-[15%] h-[600px] w-[600px] rounded-full bg-[radial-gradient(circle,var(--color-brand-900)_0%,transparent_70%)] opacity-30" />
+        <div className="absolute bottom-[-10%] right-[10%] h-[400px] w-[400px] rounded-full bg-[radial-gradient(circle,var(--color-brand-950)_0%,transparent_70%)] opacity-50" />
+      </div>
+
+      <div className="relative z-10 px-8 py-8 lg:px-12 lg:py-10">
+        <h1 className="font-[var(--font-display)] text-3xl font-bold tracking-[-0.03em] text-white">
+          Sprint Board
+        </h1>
+        <p className="mt-2 max-w-lg font-[var(--font-body)] text-base leading-[1.7] text-white/50">
+          Jira tickets enriched with PO metadata: readiness scores, priority notes, and sprint status tracking.
+        </p>
+      </div>
     </div>
   );
 }

--- a/src/app/(app)/stakeholder/page.test.tsx
+++ b/src/app/(app)/stakeholder/page.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import StakeholderPage from "./page";
+
+describe("StakeholderPage", () => {
+  it("renders the page title", () => {
+    render(<StakeholderPage />);
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("Stakeholder View");
+  });
+
+  it("renders a description", () => {
+    render(<StakeholderPage />);
+    expect(screen.getByText(/read-only external view/i)).toBeInTheDocument();
+  });
+});

--- a/src/app/(app)/stakeholder/page.tsx
+++ b/src/app/(app)/stakeholder/page.tsx
@@ -1,12 +1,19 @@
 export default function StakeholderPage() {
   return (
-    <div className="px-8 py-8 lg:px-12 lg:py-10">
-      <h1 className="font-[var(--font-display)] text-3xl font-bold tracking-[-0.03em] text-white">
-        Stakeholder
-      </h1>
-      <p className="mt-2 max-w-lg font-[var(--font-body)] text-base leading-[1.7] text-white/50">
-        Read-only external view for non-technical stakeholders.
-      </p>
+    <div className="noise-overlay relative min-h-full">
+      <div className="pointer-events-none absolute inset-0" aria-hidden="true">
+        <div className="absolute top-[-20%] left-[15%] h-[600px] w-[600px] rounded-full bg-[radial-gradient(circle,var(--color-brand-900)_0%,transparent_70%)] opacity-30" />
+        <div className="absolute bottom-[-10%] right-[10%] h-[400px] w-[400px] rounded-full bg-[radial-gradient(circle,var(--color-brand-950)_0%,transparent_70%)] opacity-50" />
+      </div>
+
+      <div className="relative z-10 px-8 py-8 lg:px-12 lg:py-10">
+        <h1 className="font-[var(--font-display)] text-3xl font-bold tracking-[-0.03em] text-white">
+          Stakeholder View
+        </h1>
+        <p className="mt-2 max-w-lg font-[var(--font-body)] text-base leading-[1.7] text-white/50">
+          Read-only external view for non-technical stakeholders to track sprint progress and project health.
+        </p>
+      </div>
     </div>
   );
 }

--- a/src/app/(app)/test-center/page.test.tsx
+++ b/src/app/(app)/test-center/page.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import TestCenterPage from "./page";
+
+describe("TestCenterPage", () => {
+  it("renders the page title", () => {
+    render(<TestCenterPage />);
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("Test Center");
+  });
+
+  it("renders a description", () => {
+    render(<TestCenterPage />);
+    expect(screen.getByText(/test status overview/i)).toBeInTheDocument();
+  });
+});

--- a/src/app/(app)/test-center/page.tsx
+++ b/src/app/(app)/test-center/page.tsx
@@ -1,12 +1,19 @@
 export default function TestCenterPage() {
   return (
-    <div className="px-8 py-8 lg:px-12 lg:py-10">
-      <h1 className="font-[var(--font-display)] text-3xl font-bold tracking-[-0.03em] text-white">
-        Test Center
-      </h1>
-      <p className="mt-2 max-w-lg font-[var(--font-body)] text-base leading-[1.7] text-white/50">
-        Test status, execution, and reports overview.
-      </p>
+    <div className="noise-overlay relative min-h-full">
+      <div className="pointer-events-none absolute inset-0" aria-hidden="true">
+        <div className="absolute top-[-20%] left-[15%] h-[600px] w-[600px] rounded-full bg-[radial-gradient(circle,var(--color-brand-900)_0%,transparent_70%)] opacity-30" />
+        <div className="absolute bottom-[-10%] right-[10%] h-[400px] w-[400px] rounded-full bg-[radial-gradient(circle,var(--color-brand-950)_0%,transparent_70%)] opacity-50" />
+      </div>
+
+      <div className="relative z-10 px-8 py-8 lg:px-12 lg:py-10">
+        <h1 className="font-[var(--font-display)] text-3xl font-bold tracking-[-0.03em] text-white">
+          Test Center
+        </h1>
+        <p className="mt-2 max-w-lg font-[var(--font-body)] text-base leading-[1.7] text-white/50">
+          Test status overview, execution controls, and detailed reports for the workspace test suite.
+        </p>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Added consistent placeholder pages with background gradients and noise overlay for all 6 views: Chat, Sprint Board, Test Center, Refinement, Scheduled Jobs, and Stakeholder View
- Each page shows a title and PRD-based description, matching the Dashboard page layout
- Added tests for all placeholder pages (12 new tests)

Closes #17

## Test plan

- [x] All 6 placeholder pages render with title and description
- [x] Consistent layout across all pages (noise overlay + background gradients)
- [x] All pages render inside the app shell layout from #16
- [x] No broken routes in the sidebar
- [x] `npm run test` passes (26/26)
- [x] `npm run build` passes