### PR TITLE
feat: add Chat API routes for conversations and messages

### DIFF
--- a/src/app/api/conversations/[id]/messages/route.test.ts
+++ b/src/app/api/conversations/[id]/messages/route.test.ts
@@ -1,0 +1,172 @@
+// @vitest-environment node
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+import * as schema from "@/db/schema";
+import { vi } from "vitest";
+
+let sqlite: InstanceType<typeof Database>;
+let testDb: ReturnType<typeof drizzle>;
+
+vi.mock("@/db", () => ({
+  get db() {
+    return testDb;
+  },
+}));
+
+beforeAll(() => {
+  sqlite = new Database(":memory:");
+  testDb = drizzle(sqlite, { schema });
+  migrate(testDb, { migrationsFolder: "./drizzle" });
+});
+
+afterAll(() => {
+  sqlite.close();
+});
+
+beforeEach(() => {
+  sqlite.exec("DELETE FROM message");
+  sqlite.exec("DELETE FROM conversation");
+
+  testDb
+    .insert(schema.conversation)
+    .values({ id: "c1", title: "Test chat", createdAt: "2026-03-28T00:00:00Z" })
+    .run();
+});
+
+function makeRequest(conversationId: string, body: unknown) {
+  return new Request(
+    `http://localhost/api/conversations/${conversationId}/messages`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    },
+  );
+}
+
+describe("POST /api/conversations/[id]/messages", () => {
+  it("creates a user message", async () => {
+    const { POST } = await import("./route");
+    const response = await POST(
+      makeRequest("c1", { role: "user", content: "Hello" }),
+      { params: Promise.resolve({ id: "c1" }) },
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(data.id).toBeDefined();
+    expect(data.conversationId).toBe("c1");
+    expect(data.role).toBe("user");
+    expect(data.content).toBe("Hello");
+    expect(data.timestamp).toBeDefined();
+  });
+
+  it("creates an assistant message", async () => {
+    const { POST } = await import("./route");
+    const response = await POST(
+      makeRequest("c1", { role: "assistant", content: "Hi there" }),
+      { params: Promise.resolve({ id: "c1" }) },
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(data.role).toBe("assistant");
+  });
+
+  it("trims whitespace from content", async () => {
+    const { POST } = await import("./route");
+    const response = await POST(
+      makeRequest("c1", { role: "user", content: "  spaced  " }),
+      { params: Promise.resolve({ id: "c1" }) },
+    );
+    const data = await response.json();
+
+    expect(data.content).toBe("spaced");
+  });
+
+  it("persists message in database", async () => {
+    const { POST } = await import("./route");
+    const response = await POST(
+      makeRequest("c1", { role: "user", content: "Stored" }),
+      { params: Promise.resolve({ id: "c1" }) },
+    );
+    const data = await response.json();
+
+    const rows = testDb.select().from(schema.message).all();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toBe(data.id);
+    expect(rows[0].content).toBe("Stored");
+  });
+
+  it("returns 404 for non-existent conversation", async () => {
+    const { POST } = await import("./route");
+    const response = await POST(
+      makeRequest("nonexistent", { role: "user", content: "Hello" }),
+      { params: Promise.resolve({ id: "nonexistent" }) },
+    );
+
+    expect(response.status).toBe(404);
+  });
+
+  it("rejects invalid role", async () => {
+    const { POST } = await import("./route");
+    const response = await POST(
+      makeRequest("c1", { role: "system", content: "Hello" }),
+      { params: Promise.resolve({ id: "c1" }) },
+    );
+
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error).toContain("role");
+  });
+
+  it("rejects missing role", async () => {
+    const { POST } = await import("./route");
+    const response = await POST(
+      makeRequest("c1", { content: "Hello" }),
+      { params: Promise.resolve({ id: "c1" }) },
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("rejects empty content", async () => {
+    const { POST } = await import("./route");
+    const response = await POST(
+      makeRequest("c1", { role: "user", content: "" }),
+      { params: Promise.resolve({ id: "c1" }) },
+    );
+
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error).toContain("content");
+  });
+
+  it("rejects missing content", async () => {
+    const { POST } = await import("./route");
+    const response = await POST(
+      makeRequest("c1", { role: "user" }),
+      { params: Promise.resolve({ id: "c1" }) },
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("rejects invalid JSON", async () => {
+    const { POST } = await import("./route");
+    const response = await POST(
+      new Request("http://localhost/api/conversations/c1/messages", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "not json",
+      }),
+      { params: Promise.resolve({ id: "c1" }) },
+    );
+
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error).toBe("Invalid JSON");
+  });
+});

--- a/src/app/api/conversations/[id]/messages/route.ts
+++ b/src/app/api/conversations/[id]/messages/route.ts
@@ -1,0 +1,63 @@
+import { NextResponse } from "next/server";
+import { db } from "@/db";
+import { conversation, message } from "@/db/schema";
+import { eq } from "drizzle-orm";
+import crypto from "node:crypto";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id: conversationId } = await params;
+
+  const conv = db
+    .select()
+    .from(conversation)
+    .where(eq(conversation.id, conversationId))
+    .get();
+
+  if (!conv) {
+    return NextResponse.json(
+      { error: "Conversation not found" },
+      { status: 404 },
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const { role, content } = body as { role?: string; content?: string };
+
+  if (!role || !["user", "assistant"].includes(role)) {
+    return NextResponse.json(
+      { error: "role must be 'user' or 'assistant'" },
+      { status: 400 },
+    );
+  }
+
+  if (!content || typeof content !== "string" || content.trim().length === 0) {
+    return NextResponse.json(
+      { error: "content is required and must be a non-empty string" },
+      { status: 400 },
+    );
+  }
+
+  const id = crypto.randomUUID();
+  const timestamp = new Date().toISOString();
+
+  const newMessage = {
+    id,
+    conversationId,
+    role: role as "user" | "assistant",
+    content: content.trim(),
+    timestamp,
+  };
+
+  db.insert(message).values(newMessage).run();
+
+  return NextResponse.json(newMessage, { status: 201 });
+}

--- a/src/app/api/conversations/[id]/route.test.ts
+++ b/src/app/api/conversations/[id]/route.test.ts
@@ -1,0 +1,169 @@
+// @vitest-environment node
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+import * as schema from "@/db/schema";
+import { vi } from "vitest";
+
+let sqlite: InstanceType<typeof Database>;
+let testDb: ReturnType<typeof drizzle>;
+
+vi.mock("@/db", () => ({
+  get db() {
+    return testDb;
+  },
+}));
+
+beforeAll(() => {
+  sqlite = new Database(":memory:");
+  testDb = drizzle(sqlite, { schema });
+  migrate(testDb, { migrationsFolder: "./drizzle" });
+});
+
+afterAll(() => {
+  sqlite.close();
+});
+
+beforeEach(() => {
+  sqlite.exec("DELETE FROM message");
+  sqlite.exec("DELETE FROM conversation");
+});
+
+function seedConversation() {
+  testDb
+    .insert(schema.conversation)
+    .values({ id: "c1", title: "Test chat", createdAt: "2026-03-28T00:00:00Z" })
+    .run();
+
+  testDb
+    .insert(schema.message)
+    .values([
+      {
+        id: "m1",
+        conversationId: "c1",
+        role: "user",
+        content: "Hello",
+        timestamp: "2026-03-28T10:00:00Z",
+      },
+      {
+        id: "m2",
+        conversationId: "c1",
+        role: "assistant",
+        content: "Hi there",
+        timestamp: "2026-03-28T10:01:00Z",
+      },
+    ])
+    .run();
+}
+
+describe("GET /api/conversations/[id]", () => {
+  it("returns conversation with messages", async () => {
+    seedConversation();
+    const { GET } = await import("./route");
+    const response = await GET(new Request("http://localhost"), {
+      params: Promise.resolve({ id: "c1" }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.id).toBe("c1");
+    expect(data.title).toBe("Test chat");
+    expect(data.messages).toHaveLength(2);
+    expect(data.messages[0].id).toBe("m1");
+    expect(data.messages[1].id).toBe("m2");
+  });
+
+  it("returns messages in chronological order", async () => {
+    seedConversation();
+    const { GET } = await import("./route");
+    const response = await GET(new Request("http://localhost"), {
+      params: Promise.resolve({ id: "c1" }),
+    });
+    const data = await response.json();
+
+    expect(data.messages[0].timestamp).toBe("2026-03-28T10:00:00Z");
+    expect(data.messages[1].timestamp).toBe("2026-03-28T10:01:00Z");
+  });
+
+  it("returns 404 for non-existent conversation", async () => {
+    const { GET } = await import("./route");
+    const response = await GET(new Request("http://localhost"), {
+      params: Promise.resolve({ id: "nonexistent" }),
+    });
+
+    expect(response.status).toBe(404);
+    const data = await response.json();
+    expect(data.error).toContain("not found");
+  });
+
+  it("returns empty messages array for conversation with no messages", async () => {
+    testDb
+      .insert(schema.conversation)
+      .values({ id: "c1", title: "Empty chat", createdAt: "2026-03-28T00:00:00Z" })
+      .run();
+
+    const { GET } = await import("./route");
+    const response = await GET(new Request("http://localhost"), {
+      params: Promise.resolve({ id: "c1" }),
+    });
+    const data = await response.json();
+
+    expect(data.messages).toEqual([]);
+  });
+});
+
+describe("DELETE /api/conversations/[id]", () => {
+  it("deletes conversation and its messages", async () => {
+    seedConversation();
+    const { DELETE } = await import("./route");
+    const response = await DELETE(new Request("http://localhost"), {
+      params: Promise.resolve({ id: "c1" }),
+    });
+
+    expect(response.status).toBe(204);
+
+    const convRows = testDb.select().from(schema.conversation).all();
+    expect(convRows).toHaveLength(0);
+
+    const msgRows = testDb.select().from(schema.message).all();
+    expect(msgRows).toHaveLength(0);
+  });
+
+  it("returns 404 for non-existent conversation", async () => {
+    const { DELETE } = await import("./route");
+    const response = await DELETE(new Request("http://localhost"), {
+      params: Promise.resolve({ id: "nonexistent" }),
+    });
+
+    expect(response.status).toBe(404);
+  });
+
+  it("does not delete messages from other conversations", async () => {
+    seedConversation();
+
+    testDb
+      .insert(schema.conversation)
+      .values({ id: "c2", title: "Other", createdAt: "2026-03-28T00:00:00Z" })
+      .run();
+    testDb
+      .insert(schema.message)
+      .values({
+        id: "m3",
+        conversationId: "c2",
+        role: "user",
+        content: "Other msg",
+        timestamp: "2026-03-28T10:00:00Z",
+      })
+      .run();
+
+    const { DELETE } = await import("./route");
+    await DELETE(new Request("http://localhost"), {
+      params: Promise.resolve({ id: "c1" }),
+    });
+
+    const remaining = testDb.select().from(schema.message).all();
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].conversationId).toBe("c2");
+  });
+});

--- a/src/app/api/conversations/[id]/route.ts
+++ b/src/app/api/conversations/[id]/route.ts
@@ -1,0 +1,63 @@
+import { NextResponse } from "next/server";
+import { db } from "@/db";
+import { conversation, message } from "@/db/schema";
+import { eq, asc } from "drizzle-orm";
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+
+  const conv = db
+    .select()
+    .from(conversation)
+    .where(eq(conversation.id, id))
+    .get();
+
+  if (!conv) {
+    return NextResponse.json(
+      { error: "Conversation not found" },
+      { status: 404 },
+    );
+  }
+
+  const messages = db
+    .select()
+    .from(message)
+    .where(eq(message.conversationId, id))
+    .orderBy(asc(message.timestamp))
+    .all();
+
+  return NextResponse.json({
+    id: conv.id,
+    title: conv.title,
+    createdAt: conv.createdAt,
+    messages,
+  });
+}
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+
+  const conv = db
+    .select()
+    .from(conversation)
+    .where(eq(conversation.id, id))
+    .get();
+
+  if (!conv) {
+    return NextResponse.json(
+      { error: "Conversation not found" },
+      { status: 404 },
+    );
+  }
+
+  db.delete(message).where(eq(message.conversationId, id)).run();
+  db.delete(conversation).where(eq(conversation.id, id)).run();
+
+  return new Response(null, { status: 204 });
+}

--- a/src/app/api/conversations/route.test.ts
+++ b/src/app/api/conversations/route.test.ts
@@ -1,0 +1,172 @@
+// @vitest-environment node
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+import * as schema from "@/db/schema";
+import { vi } from "vitest";
+
+let sqlite: InstanceType<typeof Database>;
+let testDb: ReturnType<typeof drizzle>;
+
+vi.mock("@/db", () => ({
+  get db() {
+    return testDb;
+  },
+}));
+
+beforeAll(() => {
+  sqlite = new Database(":memory:");
+  testDb = drizzle(sqlite, { schema });
+  migrate(testDb, { migrationsFolder: "./drizzle" });
+});
+
+afterAll(() => {
+  sqlite.close();
+});
+
+beforeEach(() => {
+  sqlite.exec("DELETE FROM message");
+  sqlite.exec("DELETE FROM conversation");
+});
+
+describe("GET /api/conversations", () => {
+  it("returns empty array when no conversations exist", async () => {
+    const { GET } = await import("./route");
+    const response = await GET();
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual([]);
+  });
+
+  it("returns conversations sorted by most recent message", async () => {
+    testDb
+      .insert(schema.conversation)
+      .values([
+        { id: "c1", title: "Older", createdAt: "2026-03-27T00:00:00Z" },
+        { id: "c2", title: "Newer", createdAt: "2026-03-28T00:00:00Z" },
+      ])
+      .run();
+
+    testDb
+      .insert(schema.message)
+      .values([
+        {
+          id: "m1",
+          conversationId: "c1",
+          role: "user",
+          content: "Hello",
+          timestamp: "2026-03-27T12:00:00Z",
+        },
+        {
+          id: "m2",
+          conversationId: "c2",
+          role: "user",
+          content: "Hi",
+          timestamp: "2026-03-28T12:00:00Z",
+        },
+      ])
+      .run();
+
+    const { GET } = await import("./route");
+    const response = await GET();
+    const data = await response.json();
+
+    expect(data).toHaveLength(2);
+    expect(data[0].id).toBe("c2");
+    expect(data[0].title).toBe("Newer");
+    expect(data[0].lastMessageAt).toBe("2026-03-28T12:00:00Z");
+    expect(data[1].id).toBe("c1");
+  });
+
+  it("uses createdAt as fallback when no messages exist", async () => {
+    testDb
+      .insert(schema.conversation)
+      .values({ id: "c1", title: "Empty", createdAt: "2026-03-28T10:00:00Z" })
+      .run();
+
+    const { GET } = await import("./route");
+    const response = await GET();
+    const data = await response.json();
+
+    expect(data).toHaveLength(1);
+    expect(data[0].lastMessageAt).toBe("2026-03-28T10:00:00Z");
+  });
+});
+
+describe("POST /api/conversations", () => {
+  it("creates a new conversation", async () => {
+    const { POST } = await import("./route");
+    const response = await POST(
+      new Request("http://localhost/api/conversations", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title: "New chat" }),
+      }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(data.title).toBe("New chat");
+    expect(data.id).toBeDefined();
+    expect(data.lastMessageAt).toBeDefined();
+  });
+
+  it("trims whitespace from title", async () => {
+    const { POST } = await import("./route");
+    const response = await POST(
+      new Request("http://localhost/api/conversations", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title: "  Padded title  " }),
+      }),
+    );
+    const data = await response.json();
+
+    expect(data.title).toBe("Padded title");
+  });
+
+  it("rejects empty title", async () => {
+    const { POST } = await import("./route");
+    const response = await POST(
+      new Request("http://localhost/api/conversations", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title: "" }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error).toContain("title");
+  });
+
+  it("rejects missing title", async () => {
+    const { POST } = await import("./route");
+    const response = await POST(
+      new Request("http://localhost/api/conversations", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("rejects invalid JSON", async () => {
+    const { POST } = await import("./route");
+    const response = await POST(
+      new Request("http://localhost/api/conversations", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "not json",
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error).toBe("Invalid JSON");
+  });
+});

--- a/src/app/api/conversations/route.ts
+++ b/src/app/api/conversations/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from "next/server";
+import { db } from "@/db";
+import { conversation, message } from "@/db/schema";
+import { desc, eq, max } from "drizzle-orm";
+import crypto from "node:crypto";
+
+export async function GET() {
+  const rows = db
+    .select({
+      id: conversation.id,
+      title: conversation.title,
+      createdAt: conversation.createdAt,
+      relatedTicket: conversation.relatedTicket,
+      lastMessageAt: max(message.timestamp),
+    })
+    .from(conversation)
+    .leftJoin(message, eq(conversation.id, message.conversationId))
+    .groupBy(conversation.id)
+    .orderBy(desc(max(message.timestamp)))
+    .all();
+
+  const result = rows.map((row) => ({
+    id: row.id,
+    title: row.title,
+    lastMessageAt: row.lastMessageAt ?? row.createdAt,
+  }));
+
+  return NextResponse.json(result);
+}
+
+export async function POST(request: Request) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const { title } = body as { title?: string };
+  if (!title || typeof title !== "string" || title.trim().length === 0) {
+    return NextResponse.json(
+      { error: "title is required and must be a non-empty string" },
+      { status: 400 },
+    );
+  }
+
+  const id = crypto.randomUUID();
+  const createdAt = new Date().toISOString();
+
+  db.insert(conversation)
+    .values({ id, title: title.trim(), createdAt })
+    .run();
+
+  return NextResponse.json(
+    { id, title: title.trim(), lastMessageAt: createdAt },
+    { status: 201 },
+  );
+}


### PR DESCRIPTION
## Summary

- Adds CRUD API routes for conversations and messages backed by Drizzle/SQLite
- `GET /api/conversations` returns all conversations sorted by most recent message
- `POST /api/conversations` creates a new conversation with title validation
- `GET /api/conversations/[id]` returns conversation detail with all messages in chronological order
- `DELETE /api/conversations/[id]` removes conversation and its messages (cascade)
- `POST /api/conversations/[id]/messages` adds a user or assistant message with role/content validation
- All routes include proper error handling (400, 404) and input validation
- Full test coverage for all endpoints using in-memory SQLite

## Test plan

- [x] All 85 tests pass (`npm run test`)
- [x] Build succeeds (`npm run build`)
- [x] API routes compile as dynamic server-rendered endpoints

Closes #21