### PR TITLE
feat: add Chat API routes for conversations and messages

### DIFF
--- a/src/app/api/conversations/[id]/messages/route.test.ts
+++ b/src/app/api/conversations/[id]/messages/route.test.ts
@@ -1,0 +1,190 @@
+// @vitest-environment node
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from "vitest";
+
+const dbRef = vi.hoisted(() => ({ current: null as any, sqlite: null as any }));
+
+vi.mock("@/db", () => ({
+  get db() {
+    return dbRef.current;
+  },
+}));
+
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+import * as schema from "@/db/schema";
+import { POST } from "./route";
+
+beforeAll(() => {
+  dbRef.sqlite = new Database(":memory:");
+  dbRef.current = drizzle(dbRef.sqlite, { schema });
+  migrate(dbRef.current, { migrationsFolder: "./drizzle" });
+});
+
+afterAll(() => {
+  dbRef.sqlite?.close();
+});
+
+beforeEach(() => {
+  dbRef.current.delete(schema.message).run();
+  dbRef.current.delete(schema.conversation).run();
+
+  dbRef.current
+    .insert(schema.conversation)
+    .values({ id: "c1", title: "Test conv", createdAt: "2026-03-28T00:00:00Z" })
+    .run();
+});
+
+function makeRequest(conversationId: string, body: unknown) {
+  return {
+    request: new Request(
+      `http://localhost/api/conversations/${conversationId}/messages`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      }
+    ),
+    context: { params: Promise.resolve({ id: conversationId }) },
+  };
+}
+
+describe("POST /api/conversations/[id]/messages", () => {
+  it("creates a user message", async () => {
+    const { request, context } = makeRequest("c1", {
+      role: "user",
+      content: "Hello world",
+    });
+
+    const response = await POST(request, context);
+    const data = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(data.role).toBe("user");
+    expect(data.content).toBe("Hello world");
+    expect(data.conversationId).toBe("c1");
+    expect(data.id).toBeDefined();
+    expect(data.timestamp).toBeDefined();
+    expect(data.workspaceTaskId).toBeNull();
+  });
+
+  it("creates an assistant message", async () => {
+    const { request, context } = makeRequest("c1", {
+      role: "assistant",
+      content: "I can help with that",
+    });
+
+    const response = await POST(request, context);
+    const data = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(data.role).toBe("assistant");
+  });
+
+  it("accepts optional workspaceTaskId", async () => {
+    const { request, context } = makeRequest("c1", {
+      role: "assistant",
+      content: "Task result",
+      workspaceTaskId: "wt-123",
+    });
+
+    const response = await POST(request, context);
+    const data = await response.json();
+
+    expect(data.workspaceTaskId).toBe("wt-123");
+  });
+
+  it("trims whitespace from content", async () => {
+    const { request, context } = makeRequest("c1", {
+      role: "user",
+      content: "  padded  ",
+    });
+
+    const response = await POST(request, context);
+    const data = await response.json();
+
+    expect(data.content).toBe("padded");
+  });
+
+  it("persists the message to the database", async () => {
+    const { request, context } = makeRequest("c1", {
+      role: "user",
+      content: "Stored",
+    });
+
+    await POST(request, context);
+
+    const rows = dbRef.current.select().from(schema.message).all();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].content).toBe("Stored");
+  });
+
+  it("returns 404 for non-existent conversation", async () => {
+    const { request, context } = makeRequest("nope", {
+      role: "user",
+      content: "Hello",
+    });
+
+    const response = await POST(request, context);
+    expect(response.status).toBe(404);
+
+    const data = await response.json();
+    expect(data.error).toBe("Conversation not found");
+  });
+
+  it("returns 400 when content is missing", async () => {
+    const { request, context } = makeRequest("c1", {
+      role: "user",
+    });
+
+    const response = await POST(request, context);
+    expect(response.status).toBe(400);
+
+    const data = await response.json();
+    expect(data.error).toBe("content is required");
+  });
+
+  it("returns 400 when role is missing", async () => {
+    const { request, context } = makeRequest("c1", {
+      content: "Hello",
+    });
+
+    const response = await POST(request, context);
+    expect(response.status).toBe(400);
+
+    const data = await response.json();
+    expect(data.error).toBe("role must be 'user' or 'assistant'");
+  });
+
+  it("returns 400 when role is invalid", async () => {
+    const { request, context } = makeRequest("c1", {
+      role: "system",
+      content: "Hello",
+    });
+
+    const response = await POST(request, context);
+    expect(response.status).toBe(400);
+
+    const data = await response.json();
+    expect(data.error).toBe("role must be 'user' or 'assistant'");
+  });
+
+  it("returns 400 for invalid JSON", async () => {
+    const request = new Request(
+      "http://localhost/api/conversations/c1/messages",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "not json",
+      }
+    );
+
+    const response = await POST(request, {
+      params: Promise.resolve({ id: "c1" }),
+    });
+    expect(response.status).toBe(400);
+
+    const data = await response.json();
+    expect(data.error).toBe("Invalid JSON");
+  });
+});

--- a/src/app/api/conversations/[id]/messages/route.ts
+++ b/src/app/api/conversations/[id]/messages/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from "next/server";
+import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
+import { db } from "@/db";
+import { conversation, message } from "@/db/schema";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  const conv = db
+    .select()
+    .from(conversation)
+    .where(eq(conversation.id, id))
+    .get();
+
+  if (!conv) {
+    return NextResponse.json(
+      { error: "Conversation not found" },
+      { status: 404 }
+    );
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  if (!body.content || typeof body.content !== "string") {
+    return NextResponse.json(
+      { error: "content is required" },
+      { status: 400 }
+    );
+  }
+
+  if (!body.role || !["user", "assistant"].includes(body.role as string)) {
+    return NextResponse.json(
+      { error: "role must be 'user' or 'assistant'" },
+      { status: 400 }
+    );
+  }
+
+  const row = {
+    id: randomUUID(),
+    conversationId: id,
+    role: body.role as "user" | "assistant",
+    content: (body.content as string).trim(),
+    timestamp: new Date().toISOString(),
+    workspaceTaskId: (body.workspaceTaskId as string) ?? null,
+  };
+
+  db.insert(message).values(row).run();
+
+  return NextResponse.json(row, { status: 201 });
+}

--- a/src/app/api/conversations/[id]/route.test.ts
+++ b/src/app/api/conversations/[id]/route.test.ts
@@ -1,0 +1,207 @@
+// @vitest-environment node
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from "vitest";
+
+const dbRef = vi.hoisted(() => ({ current: null as any, sqlite: null as any }));
+
+vi.mock("@/db", () => ({
+  get db() {
+    return dbRef.current;
+  },
+}));
+
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+import * as schema from "@/db/schema";
+import { GET, DELETE } from "./route";
+
+beforeAll(() => {
+  dbRef.sqlite = new Database(":memory:");
+  dbRef.current = drizzle(dbRef.sqlite, { schema });
+  migrate(dbRef.current, { migrationsFolder: "./drizzle" });
+});
+
+afterAll(() => {
+  dbRef.sqlite?.close();
+});
+
+beforeEach(() => {
+  dbRef.current.delete(schema.message).run();
+  dbRef.current.delete(schema.conversation).run();
+});
+
+function makeParams(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+describe("GET /api/conversations/[id]", () => {
+  it("returns conversation with its messages", async () => {
+    dbRef.current
+      .insert(schema.conversation)
+      .values({ id: "c1", title: "Test", createdAt: "2026-03-28T00:00:00Z" })
+      .run();
+
+    dbRef.current
+      .insert(schema.message)
+      .values([
+        {
+          id: "m1",
+          conversationId: "c1",
+          role: "user",
+          content: "Hello",
+          timestamp: "2026-03-28T00:00:01Z",
+        },
+        {
+          id: "m2",
+          conversationId: "c1",
+          role: "assistant",
+          content: "Hi there",
+          timestamp: "2026-03-28T00:00:02Z",
+        },
+      ])
+      .run();
+
+    const response = await GET(
+      new Request("http://localhost/api/conversations/c1"),
+      makeParams("c1")
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.id).toBe("c1");
+    expect(data.title).toBe("Test");
+    expect(data.messages).toHaveLength(2);
+    expect(data.messages[0].id).toBe("m1");
+    expect(data.messages[1].id).toBe("m2");
+  });
+
+  it("returns messages ordered by timestamp", async () => {
+    dbRef.current
+      .insert(schema.conversation)
+      .values({ id: "c1", title: "Test", createdAt: "2026-03-28T00:00:00Z" })
+      .run();
+
+    dbRef.current
+      .insert(schema.message)
+      .values([
+        {
+          id: "m-late",
+          conversationId: "c1",
+          role: "assistant",
+          content: "Second",
+          timestamp: "2026-03-28T00:00:10Z",
+        },
+        {
+          id: "m-early",
+          conversationId: "c1",
+          role: "user",
+          content: "First",
+          timestamp: "2026-03-28T00:00:01Z",
+        },
+      ])
+      .run();
+
+    const response = await GET(
+      new Request("http://localhost/api/conversations/c1"),
+      makeParams("c1")
+    );
+    const data = await response.json();
+
+    expect(data.messages[0].id).toBe("m-early");
+    expect(data.messages[1].id).toBe("m-late");
+  });
+
+  it("returns empty messages array when conversation has no messages", async () => {
+    dbRef.current
+      .insert(schema.conversation)
+      .values({ id: "c1", title: "Empty", createdAt: "2026-03-28T00:00:00Z" })
+      .run();
+
+    const response = await GET(
+      new Request("http://localhost/api/conversations/c1"),
+      makeParams("c1")
+    );
+    const data = await response.json();
+
+    expect(data.messages).toEqual([]);
+  });
+
+  it("returns 404 for non-existent conversation", async () => {
+    const response = await GET(
+      new Request("http://localhost/api/conversations/nope"),
+      makeParams("nope")
+    );
+
+    expect(response.status).toBe(404);
+
+    const data = await response.json();
+    expect(data.error).toBe("Conversation not found");
+  });
+});
+
+describe("DELETE /api/conversations/[id]", () => {
+  it("deletes a conversation and its messages", async () => {
+    dbRef.current
+      .insert(schema.conversation)
+      .values({ id: "c1", title: "Doomed", createdAt: "2026-03-28T00:00:00Z" })
+      .run();
+
+    dbRef.current
+      .insert(schema.message)
+      .values({
+        id: "m1",
+        conversationId: "c1",
+        role: "user",
+        content: "Goodbye",
+        timestamp: "2026-03-28T00:00:01Z",
+      })
+      .run();
+
+    const response = await DELETE(
+      new Request("http://localhost/api/conversations/c1", { method: "DELETE" }),
+      makeParams("c1")
+    );
+
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data.success).toBe(true);
+
+    const convRows = dbRef.current.select().from(schema.conversation).all();
+    expect(convRows).toHaveLength(0);
+
+    const msgRows = dbRef.current.select().from(schema.message).all();
+    expect(msgRows).toHaveLength(0);
+  });
+
+  it("does not delete other conversations", async () => {
+    dbRef.current
+      .insert(schema.conversation)
+      .values([
+        { id: "c1", title: "Delete me", createdAt: "2026-03-28T00:00:00Z" },
+        { id: "c2", title: "Keep me", createdAt: "2026-03-28T00:00:00Z" },
+      ])
+      .run();
+
+    await DELETE(
+      new Request("http://localhost/api/conversations/c1", { method: "DELETE" }),
+      makeParams("c1")
+    );
+
+    const rows = dbRef.current.select().from(schema.conversation).all();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toBe("c2");
+  });
+
+  it("returns 404 for non-existent conversation", async () => {
+    const response = await DELETE(
+      new Request("http://localhost/api/conversations/nope", { method: "DELETE" }),
+      makeParams("nope")
+    );
+
+    expect(response.status).toBe(404);
+
+    const data = await response.json();
+    expect(data.error).toBe("Conversation not found");
+  });
+});

--- a/src/app/api/conversations/[id]/route.ts
+++ b/src/app/api/conversations/[id]/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from "next/server";
+import { asc, eq } from "drizzle-orm";
+import { db } from "@/db";
+import { conversation, message } from "@/db/schema";
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  const conv = db
+    .select()
+    .from(conversation)
+    .where(eq(conversation.id, id))
+    .get();
+
+  if (!conv) {
+    return NextResponse.json(
+      { error: "Conversation not found" },
+      { status: 404 }
+    );
+  }
+
+  const messages = db
+    .select()
+    .from(message)
+    .where(eq(message.conversationId, id))
+    .orderBy(asc(message.timestamp))
+    .all();
+
+  return NextResponse.json({ ...conv, messages });
+}
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  const conv = db
+    .select()
+    .from(conversation)
+    .where(eq(conversation.id, id))
+    .get();
+
+  if (!conv) {
+    return NextResponse.json(
+      { error: "Conversation not found" },
+      { status: 404 }
+    );
+  }
+
+  db.delete(message).where(eq(message.conversationId, id)).run();
+  db.delete(conversation).where(eq(conversation.id, id)).run();
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/conversations/route.test.ts
+++ b/src/app/api/conversations/route.test.ts
@@ -1,0 +1,180 @@
+// @vitest-environment node
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from "vitest";
+
+const dbRef = vi.hoisted(() => ({ current: null as any, sqlite: null as any }));
+
+vi.mock("@/db", () => ({
+  get db() {
+    return dbRef.current;
+  },
+}));
+
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+import * as schema from "@/db/schema";
+import { GET, POST } from "./route";
+
+beforeAll(() => {
+  dbRef.sqlite = new Database(":memory:");
+  dbRef.current = drizzle(dbRef.sqlite, { schema });
+  migrate(dbRef.current, { migrationsFolder: "./drizzle" });
+});
+
+afterAll(() => {
+  dbRef.sqlite?.close();
+});
+
+beforeEach(() => {
+  dbRef.current.delete(schema.message).run();
+  dbRef.current.delete(schema.conversation).run();
+});
+
+describe("GET /api/conversations", () => {
+  it("returns empty array when no conversations exist", async () => {
+    const response = await GET();
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual([]);
+  });
+
+  it("returns conversations sorted by most recent activity", async () => {
+    dbRef.current
+      .insert(schema.conversation)
+      .values([
+        { id: "old", title: "Old chat", createdAt: "2026-03-01T00:00:00Z" },
+        { id: "new", title: "New chat", createdAt: "2026-03-02T00:00:00Z" },
+      ])
+      .run();
+
+    const response = await GET();
+    const data = await response.json();
+
+    expect(data).toHaveLength(2);
+    expect(data[0].id).toBe("new");
+    expect(data[1].id).toBe("old");
+  });
+
+  it("sorts by latest message timestamp when messages exist", async () => {
+    dbRef.current
+      .insert(schema.conversation)
+      .values([
+        { id: "c1", title: "First", createdAt: "2026-03-01T00:00:00Z" },
+        { id: "c2", title: "Second", createdAt: "2026-03-02T00:00:00Z" },
+      ])
+      .run();
+
+    dbRef.current
+      .insert(schema.message)
+      .values({
+        id: "m1",
+        conversationId: "c1",
+        role: "user",
+        content: "Hello",
+        timestamp: "2026-03-10T00:00:00Z",
+      })
+      .run();
+
+    const response = await GET();
+    const data = await response.json();
+
+    expect(data[0].id).toBe("c1");
+    expect(data[0].lastMessageAt).toBe("2026-03-10T00:00:00Z");
+    expect(data[1].id).toBe("c2");
+    expect(data[1].lastMessageAt).toBeNull();
+  });
+});
+
+describe("POST /api/conversations", () => {
+  it("creates a conversation with valid title", async () => {
+    const request = new Request("http://localhost/api/conversations", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "New conversation" }),
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(data.title).toBe("New conversation");
+    expect(data.id).toBeDefined();
+    expect(data.createdAt).toBeDefined();
+    expect(data.relatedTicket).toBeNull();
+  });
+
+  it("creates a conversation with relatedTicket", async () => {
+    const request = new Request("http://localhost/api/conversations", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "Ticket chat", relatedTicket: "VALK-100" }),
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(data.relatedTicket).toBe("VALK-100");
+  });
+
+  it("returns 400 when title is missing", async () => {
+    const request = new Request("http://localhost/api/conversations", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    const response = await POST(request);
+    expect(response.status).toBe(400);
+
+    const data = await response.json();
+    expect(data.error).toBe("title is required");
+  });
+
+  it("returns 400 for invalid JSON", async () => {
+    const request = new Request("http://localhost/api/conversations", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not json",
+    });
+
+    const response = await POST(request);
+    expect(response.status).toBe(400);
+
+    const data = await response.json();
+    expect(data.error).toBe("Invalid JSON");
+  });
+
+  it("trims whitespace from title", async () => {
+    const request = new Request("http://localhost/api/conversations", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "  padded title  " }),
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(data.title).toBe("padded title");
+  });
+
+  it("persists the conversation to the database", async () => {
+    const request = new Request("http://localhost/api/conversations", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "Persisted" }),
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    const rows = dbRef.current
+      .select()
+      .from(schema.conversation)
+      .all();
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toBe(data.id);
+  });
+});

--- a/src/app/api/conversations/route.ts
+++ b/src/app/api/conversations/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server";
+import { randomUUID } from "node:crypto";
+import { desc, eq, sql } from "drizzle-orm";
+import { db } from "@/db";
+import { conversation, message } from "@/db/schema";
+
+export async function GET() {
+  const rows = db
+    .select({
+      id: conversation.id,
+      title: conversation.title,
+      createdAt: conversation.createdAt,
+      relatedTicket: conversation.relatedTicket,
+      lastMessageAt: sql<string | null>`MAX(${message.timestamp})`,
+    })
+    .from(conversation)
+    .leftJoin(message, eq(conversation.id, message.conversationId))
+    .groupBy(conversation.id)
+    .orderBy(
+      desc(
+        sql`COALESCE(MAX(${message.timestamp}), ${conversation.createdAt})`
+      )
+    )
+    .all();
+
+  return NextResponse.json(rows);
+}
+
+export async function POST(request: Request) {
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  if (!body.title || typeof body.title !== "string") {
+    return NextResponse.json({ error: "title is required" }, { status: 400 });
+  }
+
+  const row = {
+    id: randomUUID(),
+    title: (body.title as string).trim(),
+    createdAt: new Date().toISOString(),
+    relatedTicket: (body.relatedTicket as string) ?? null,
+  };
+
+  db.insert(conversation).values(row).run();
+
+  return NextResponse.json(row, { status: 201 });
+}


### PR DESCRIPTION
## Summary

- Add CRUD API endpoints for conversations and messages backed by Drizzle/SQLite
- `GET /api/conversations` returns all conversations sorted by most recent activity (using latest message timestamp)
- `POST /api/conversations` creates a new conversation with title and optional related ticket
- `GET /api/conversations/[id]` returns a conversation with all its messages ordered by timestamp
- `DELETE /api/conversations/[id]` removes a conversation and all its messages
- `POST /api/conversations/[id]/messages` adds a message (user or assistant role) to a conversation
- All routes include input validation, proper error handling, and 404 responses for missing conversations
- Comprehensive test suite (25 tests) using in-memory SQLite

Closes #21

## Test plan

- [x] All 86 tests pass (`npm run test`)
- [x] Production build succeeds (`npm run build`)
- [x] API routes appear as dynamic routes in build output
- [ ] CI pipeline passes