### PR TITLE
feat: add changelog link to sidebar navigation

### DIFF
--- a/src/components/Sidebar.test.tsx
+++ b/src/components/Sidebar.test.tsx
@@ -24,7 +24,7 @@ describe("Sidebar", () => {
     expect(screen.getByText("valk-command")).toBeInTheDocument();
   });
 
-  it("renders all 7 navigation items", () => {
+  it("renders all 8 navigation items", () => {
     render(<Sidebar />);
     expect(screen.getByText("Dashboard")).toBeInTheDocument();
     expect(screen.getByText("Chat")).toBeInTheDocument();
@@ -33,6 +33,7 @@ describe("Sidebar", () => {
     expect(screen.getByText("Refinement")).toBeInTheDocument();
     expect(screen.getByText("Jobs")).toBeInTheDocument();
     expect(screen.getByText("Stakeholder")).toBeInTheDocument();
+    expect(screen.getByText("Changelog")).toBeInTheDocument();
   });
 
   it("all navigation links point to correct routes", () => {
@@ -48,6 +49,7 @@ describe("Sidebar", () => {
       "/refinement",
       "/jobs",
       "/stakeholder",
+      "/changelog",
     ]);
   });
 
@@ -56,6 +58,15 @@ describe("Sidebar", () => {
     render(<Sidebar />);
     const chatLink = screen.getByText("Chat").closest("a");
     expect(chatLink).toHaveAttribute("aria-current", "page");
+    const dashboardLink = screen.getByText("Dashboard").closest("a");
+    expect(dashboardLink).not.toHaveAttribute("aria-current");
+  });
+
+  it("highlights Changelog when pathname is /changelog", () => {
+    mockUsePathname.mockReturnValue("/changelog");
+    render(<Sidebar />);
+    const changelogLink = screen.getByText("Changelog").closest("a");
+    expect(changelogLink).toHaveAttribute("aria-current", "page");
     const dashboardLink = screen.getByText("Dashboard").closest("a");
     expect(dashboardLink).not.toHaveAttribute("aria-current");
   });

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -68,6 +68,15 @@ const navItems = [
       </svg>
     ),
   },
+  {
+    label: "Changelog",
+    href: "/changelog",
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} className="h-5 w-5">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
+      </svg>
+    ),
+  },
 ];
 
 export default function Sidebar() {


### PR DESCRIPTION
## Summary

- Adds a "Changelog" navigation item to `src/components/Sidebar.tsx` with a document icon
- Links to `/changelog` with correct active state highlighting
- Includes tests for the new nav item, route, and active state

Closes #30

## Test plan

- [x] All 85 tests pass (`npm run test`)
- [x] Build succeeds (`npm run build`)
- [x] Changelog link renders in sidebar with document icon
- [x] Active state works when navigating to `/changelog`
- [x] All existing nav items unaffected